### PR TITLE
Typed parameters

### DIFF
--- a/Deeper/DeepLinkPatternConvertible.swift
+++ b/Deeper/DeepLinkPatternConvertible.swift
@@ -30,8 +30,8 @@ extension String: DeepLinkPatternConvertible {
         
         if component == "*" {
             return [.any]
-        } else if component.hasPrefix(":") {
-            return [.param(DeepLinkPatternParameter(String(component.dropFirst())))]
+        } else if component.trimPrefix(":") {
+            return [.param(DeepLinkPatternParameter(component))]
         } else {
             let orComponents = component.components(separatedBy: "|", excludingDelimiterBetween: ("(", ")"))
             if orComponents.count > 1 {
@@ -53,9 +53,33 @@ extension String: DeepLinkPatternConvertible {
     
 }
 
+// stolen from Sourcery source code ¯\_(ツ)_/¯
 extension String {
     
-    // stolen from Sourcery source code ¯\_(ツ)_/¯
+    @discardableResult
+    mutating func trimPrefix(_ prefix: String) -> Bool {
+        guard hasPrefix(prefix) else { return false }
+        self = String(characters.suffix(characters.count - prefix.characters.count))
+        return true
+    }
+
+    func trimmingPrefix(_ prefix: String) -> String {
+        guard hasPrefix(prefix) else { return self }
+        return String(characters.suffix(characters.count - prefix.characters.count))
+    }
+
+    @discardableResult
+    mutating func trimSuffix(_ suffix: String) -> Bool {
+        guard hasSuffix(suffix) else { return false }
+        self = String(characters.prefix(characters.count - suffix.characters.count))
+        return true
+    }
+
+    func trimmingSuffix(_ suffix: String) -> String {
+        guard hasSuffix(suffix) else { return self }
+        return String(characters.prefix(characters.count - suffix.characters.count))
+    }
+
     func components(separatedBy delimiter: String, excludingDelimiterBetween between: (open: String, close: String)) -> [String] {
         var boundingCharactersCount: Int = 0
         var quotesCount: Int = 0

--- a/Deeper/DeepLinkPatternMatcher.swift
+++ b/Deeper/DeepLinkPatternMatcher.swift
@@ -83,7 +83,19 @@ public class DeepLinkPatternMatcher {
         case .string(let string):
             return (pathComponent == string, [:])
         case .param(let param):
-            return (true, [param: pathComponent])
+            if let type = param.type {
+                if type.validate(pathComponent) {
+                    if !param.rawValue.isEmpty {
+                        return (true, [param: pathComponent])
+                    } else {
+                        return (true, [:])
+                    }
+                } else {
+                    return (false, [:])
+                }
+            } else {
+                return (true, [param: pathComponent])
+            }
         case .or(let lhs, let rhs):
             // Tries to recursively match longest pattern first with the rest of path components
             let patterns = [lhs.pattern, rhs.pattern].sorted(by: { $0.count > $1.count })


### PR DESCRIPTION
With this it's possible to use `:num(name)`, `:str(name)` or `:bool(name)` in patterns to additionally match types of parameters. Parameter name is optional, if not provided (i.e. `:num()`) value will matched by type but will not be passed to handler.