### PR TITLE
Handling query parameters

### DIFF
--- a/Deeper.xcodeproj/project.pbxproj
+++ b/Deeper.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6341096A1F9540CA00274FAA /* DeepLinkQueryPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634109691F9540CA00274FAA /* DeepLinkQueryPattern.swift */; };
 		634EC4F41F8C3AD40075091D /* DeepLinkPatternMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634EC4F31F8C3AD40075091D /* DeepLinkPatternMatcher.swift */; };
 		634EC4F61F8D653E0075091D /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634EC4F51F8D653E0075091D /* Utils.swift */; };
 		63BAF4BC1F7D7E310003DF2D /* Deeper.h in Headers */ = {isa = PBXBuildFile; fileRef = 63BAF4BA1F7D7E310003DF2D /* Deeper.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -33,6 +34,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		634109691F9540CA00274FAA /* DeepLinkQueryPattern.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkQueryPattern.swift; sourceTree = "<group>"; };
 		634EC4F31F8C3AD40075091D /* DeepLinkPatternMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkPatternMatcher.swift; sourceTree = "<group>"; };
 		634EC4F51F8D653E0075091D /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		63BAF4B71F7D7E310003DF2D /* Deeper.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Deeper.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -98,6 +100,7 @@
 				63C90E001F8C04C8003A5012 /* DeepLinkHandler.swift */,
 				63C90E041F8C0526003A5012 /* DeepLinkPatternConvertible.swift */,
 				63C90E061F8C0598003A5012 /* DeepLinkPattern.swift */,
+				634109691F9540CA00274FAA /* DeepLinkQueryPattern.swift */,
 				634EC4F31F8C3AD40075091D /* DeepLinkPatternMatcher.swift */,
 				63C90E081F8C05B0003A5012 /* DeepLinkRoute.swift */,
 				63C90E0E1F8C060B003A5012 /* DeepLinkRouter.swift */,
@@ -236,6 +239,7 @@
 				63C90DFD1F8C03C4003A5012 /* DeepLink.swift in Sources */,
 				63C90E071F8C0598003A5012 /* DeepLinkPattern.swift in Sources */,
 				63C90E051F8C0526003A5012 /* DeepLinkPatternConvertible.swift in Sources */,
+				6341096A1F9540CA00274FAA /* DeepLinkQueryPattern.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Deeper/DeepLinkPatternConvertible.swift
+++ b/Deeper/DeepLinkPatternConvertible.swift
@@ -22,6 +22,9 @@ extension String: DeepLinkPatternConvertible {
     
     public var pattern: [DeepLinkPattern] {
         var component = self
+        if let queryStart = component.index(of: "?") {
+            component = String(component.prefix(upTo: queryStart))
+        }
         var wrappedInBrackets = false
         if component.hasPrefix("(") && component.hasSuffix(")") {
             component = String(component.dropFirst().dropLast())
@@ -51,6 +54,14 @@ extension String: DeepLinkPatternConvertible {
         }
     }
     
+    var query: [DeepLinkQueryPattern] {
+        guard let queryStart = index(of: "?") else { return [] }
+
+        let component = String(suffix(from: queryStart).dropFirst())
+        return component.components(separatedBy: "&").map({
+            DeepLinkQueryPattern.param(DeepLinkPatternParameter($0))
+        })
+    }
 }
 
 // stolen from Sourcery source code ¯\_(ツ)_/¯

--- a/Deeper/DeepLinkQueryPattern.swift
+++ b/Deeper/DeepLinkQueryPattern.swift
@@ -1,0 +1,35 @@
+//
+//  DeepLinkQueryPattern.swift
+//  Deeper
+//
+//  Created by Ilya Puchka on 16/10/2017.
+//  Copyright © 2017 Ilya Puchka. All rights reserved.
+//
+
+public enum DeepLinkQueryPattern: CustomStringConvertible, Equatable {
+    case param(DeepLinkPatternParameter)
+    case maybe(DeepLinkPatternParameter)
+    case or(DeepLinkPatternParameter, DeepLinkPatternParameter)
+    
+    public var description: String {
+        switch self {
+        case let .param(param): return ":\(param)"
+        case let .maybe(param): return "(:\(param))"
+        case let .or(lhs, rhs): return "(:\(lhs)|:\(rhs)"
+        }
+    }
+    
+    public static func ==(lhs: DeepLinkQueryPattern, rhs: DeepLinkQueryPattern) -> Bool {
+        switch (lhs, rhs) {
+        case let (.param(lhsParam), .param(rhsParam)):
+            return lhsParam == rhsParam
+        case let (.maybe(lhsParam), .maybe(rhsParam)):
+            return lhsParam == rhsParam
+        case let (.or(lhsParams), .or(rhsParams)):
+            return lhsParams == rhsParams
+        default:
+            return false
+        }
+    }
+    
+}

--- a/Deeper/DeepLinkRoute.swift
+++ b/Deeper/DeepLinkRoute.swift
@@ -6,17 +6,22 @@
 //  Copyright © 2017 Ilya Puchka. All rights reserved.
 //
 
-public struct DeepLinkRoute: DeepLinkPatternConvertible, RawRepresentable {
+public struct DeepLinkRoute: DeepLinkPatternConvertible, RawRepresentable, Hashable, ExpressibleByStringLiteral {
     
     public let pattern: [DeepLinkPattern]
+    public let query: [DeepLinkQueryPattern]
+    
     public let rawValue: String
     
-    public init(pattern: [DeepLinkPattern]) {
+    public init(pattern: [DeepLinkPattern], query: [DeepLinkQueryPattern] = []) {
         self.pattern = pattern.filter({
             if case let .string(value) = $0 { return !value.isEmpty }
             else { return true }
         })
-        self.rawValue = pattern.map({ $0.description }).joined(separator: "/")
+        self.query = query
+        let pathPattern = pattern.map({ "\($0)" }).joined(separator: "/")
+        let queryPattern = query.map({ "\($0)" }).joined(separator: "&")
+        self.rawValue = "\(pathPattern)\(!queryPattern.isEmpty ? "?\(queryPattern)" : "")"
     }
     
     public init(rawValue: String) {
@@ -24,20 +29,22 @@ public struct DeepLinkRoute: DeepLinkPatternConvertible, RawRepresentable {
     }
 
     public init(_ rawValue: String) {
-        self.init(pattern: rawValue.pattern)
+        self.init(pattern: rawValue.pattern, query: rawValue.query)
+    }
+
+    public init(stringLiteral value: String) {
+        self.init(pattern: value.pattern)
     }
 
     public func match(url: URL) -> DeepLinkPatternMatcher.Result {
         let matcher = DeepLinkPatternMatcher(
             pattern: pattern,
-            pathComponents: ([url.host].flatMap({ $0 }) + url.pathComponents)
+            pathComponents: ([url.host].flatMap({ $0 }) + url.pathComponents),
+            query: query,
+            queryItems: URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
         )
         return matcher.match()
     }
-    
-}
-
-extension DeepLinkRoute: Hashable {
     
     public var hashValue: Int {
         return rawValue.hashValue
@@ -47,20 +54,39 @@ extension DeepLinkRoute: Hashable {
         return lhs.description == rhs.description
     }
     
-}
-
-extension DeepLinkRoute: CustomStringConvertible {
-
     public var description: String {
         return rawValue
     }
 
 }
 
-extension DeepLinkRoute: ExpressibleByStringLiteral {
+public struct DeepLinkRouteWithQuery: CustomStringConvertible, ExpressibleByStringLiteral {
+    public let route: DeepLinkRoute
     
     public init(stringLiteral value: String) {
-        self.init(pattern: value.pattern)
+        self.init(pattern: value.pattern, query: value.query)
     }
 
+    init(pattern: [DeepLinkPattern], query: [DeepLinkQueryPattern]) {
+        self.route = DeepLinkRoute(pattern: pattern, query: query)
+    }
+    
+    public var description: String {
+        return route.description
+    }
+    
+}
+
+public protocol DeepLinkRouteConvertible: CustomStringConvertible {
+    var route: DeepLinkRoute { get }
+}
+
+extension DeepLinkRoute: DeepLinkRouteConvertible {
+    public var route: DeepLinkRoute { return self }
+}
+
+extension DeepLinkRouteWithQuery: DeepLinkRouteConvertible {}
+
+extension String: DeepLinkRouteConvertible {
+    public var route: DeepLinkRoute { return DeepLinkRoute(self) }
 }

--- a/Deeper/DeepLinkRouter.swift
+++ b/Deeper/DeepLinkRouter.swift
@@ -19,7 +19,8 @@ public class DeepLinkRouter<Handler: DeepLinkHandler> {
         self.rootDeepLinkHandler = rootDeepLinkHandler
     }
     
-    public func add(routes: [DeepLinkRoute], handler: @escaping HandlerClosure) {
+    public func add(routes: [DeepLinkRouteConvertible], handler: @escaping HandlerClosure) {
+        let routes = routes.map({ $0.route })
         routesPreference.append(contentsOf: routes)
         routes.forEach({ routesHandlers[$0] = handler })
     }

--- a/Deeper/Deeper.swift
+++ b/Deeper/Deeper.swift
@@ -73,3 +73,36 @@ public func |(lhs: DeepLinkRoute, rhs: DeepLinkPatternParameter) -> DeepLinkRout
 public func |(lhs: DeepLinkPatternParameter, rhs: DeepLinkRoute) -> DeepLinkRoute {
     return DeepLinkRoute(pattern: [.or(lhs, rhs)])
 }
+
+infix operator .? : MultiplicationPrecedence
+infix operator .?? : MultiplicationPrecedence
+
+public func .?(lhs: DeepLinkRoute, rhs: DeepLinkQueryPattern) -> DeepLinkRouteWithQuery {
+    return DeepLinkRouteWithQuery(pattern: lhs.pattern, query: [rhs])
+}
+
+public func .?(lhs: DeepLinkRoute, rhs: DeepLinkPatternParameter) -> DeepLinkRouteWithQuery {
+    return DeepLinkRouteWithQuery(pattern: lhs.pattern, query: [.param(rhs)])
+}
+
+public func .??(lhs: DeepLinkRoute, rhs: DeepLinkPatternParameter) -> DeepLinkRouteWithQuery {
+    return DeepLinkRouteWithQuery(pattern: lhs.pattern, query: [.maybe(rhs)])
+}
+
+public func &(lhs: DeepLinkRouteWithQuery, rhs: DeepLinkQueryPattern) -> DeepLinkRouteWithQuery {
+    return DeepLinkRouteWithQuery(pattern: lhs.route.pattern, query: lhs.route.query + [rhs])
+}
+
+public func &(lhs: DeepLinkRouteWithQuery, rhs: DeepLinkPatternParameter) -> DeepLinkRouteWithQuery {
+    return DeepLinkRouteWithQuery(pattern: lhs.route.pattern, query: lhs.route.query + [.param(rhs)])
+}
+
+infix operator &? : MultiplicationPrecedence
+
+public func &?(lhs: DeepLinkRouteWithQuery, rhs: DeepLinkPatternParameter) -> DeepLinkRouteWithQuery {
+    return DeepLinkRouteWithQuery(pattern: lhs.route.pattern, query: lhs.route.query + [.maybe(rhs)])
+}
+
+public func |(lhs: DeepLinkPatternParameter, rhs: DeepLinkPatternParameter) -> DeepLinkQueryPattern {
+    return .or(lhs, rhs)
+}

--- a/DeeperTests/DeeperTests.swift
+++ b/DeeperTests/DeeperTests.swift
@@ -288,6 +288,71 @@ class DeeperTests: XCTestCase {
         XCTAssertFalse(route.match(url: url).0, "can't have two any next to each other")
     }
     
+    func testThatPatternMatchesQueryParameters() {
+        var route: DeepLinkRouteConvertible
+        var url: URL
+
+        route = "recipe" .? .recipeId & .menuId
+
+        url = URL(string: "http://recipe?recipeId=1&menuId=2")!
+        XCTAssertTrue(route.route.match(url: url).0)
+        XCTAssertEqual(route.route.match(url: url).1, [.recipeId: "1", .menuId: "2"])
+
+        url = URL(string: "http://recipe?menuId=2&recipeId=1")!
+        XCTAssertTrue(route.route.match(url: url).0)
+        XCTAssertEqual(route.route.match(url: url).1, [.recipeId: "1", .menuId: "2"])
+
+        url = URL(string: "http://recipe?recipeId=1&menuId=abc")!
+        XCTAssertFalse(route.route.match(url: url).0)
+
+        url = URL(string: "http://recipe?recipeId=1")!
+        XCTAssertFalse(route.route.match(url: url).0)
+
+        url = URL(string: "http://recipe?menuId=2")!
+        XCTAssertFalse(route.route.match(url: url).0)
+
+        url = URL(string: "http://recipe?recipeId=1&orderId=2")!
+        XCTAssertFalse(route.route.match(url: url).0)
+
+        route = "recipe" .?? .recipeId & .menuId
+
+        url = URL(string: "http://recipe?recipeId=1&menuId=2")!
+        XCTAssertTrue(route.route.match(url: url).0)
+        XCTAssertEqual(route.route.match(url: url).1, [.recipeId: "1", .menuId: "2"])
+
+        url = URL(string: "http://recipe?menuId=2")!
+        XCTAssertTrue(route.route.match(url: url).0)
+        XCTAssertEqual(route.route.match(url: url).1, [.menuId: "2"])
+
+        route = "recipe" .? .recipeId &? .menuId
+        
+        url = URL(string: "http://recipe?recipeId=1&menuId=2")!
+        XCTAssertTrue(route.route.match(url: url).0)
+        XCTAssertEqual(route.route.match(url: url).1, [.recipeId: "1", .menuId: "2"])
+
+        url = URL(string: "http://recipe?recipeId=1")!
+        XCTAssertTrue(route.route.match(url: url).0)
+        XCTAssertEqual(route.route.match(url: url).1, [.recipeId: "1"])
+
+        route = "recipe" .?? .recipeId &? .menuId
+
+        url = URL(string: "http://recipe")!
+        XCTAssertTrue(route.route.match(url: url).0)
+
+        route = "recipe" .? (.recipeId | .menuId)
+        
+        url = URL(string: "http://recipe?recipeId=1")!
+        XCTAssertTrue(route.route.match(url: url).0)
+        XCTAssertEqual(route.route.match(url: url).1, [.recipeId: "1"])
+        
+        url = URL(string: "http://recipe?menuId=2")!
+        XCTAssertTrue(route.route.match(url: url).0)
+        XCTAssertEqual(route.route.match(url: url).1, [.menuId: "2"])
+        
+        url = URL(string: "http://recipe")!
+        XCTAssertFalse(route.route.match(url: url).0)
+    }
+    
     func testStringToPatternConversion() {
         let pattern = "(recipe|recipes|recipes/archive)/*/details/(info)/:num(menuId)/:recipeId".pattern
         let expectedPattern: [DeepLinkPattern] = [


### PR DESCRIPTION
This PR adds support for query parameters. Their order does not matter, additional query parameters are ignored, but all mentioned parameters (unless they are optional) are required. Supports `.maybe` and `.or` patterns.

Operators:
`.? param` - marks start of the query with some required parameter (position of parameter in actually query string does not matter)
`.?? param` - the same but parameter is treated as optional
`.& param` - appends required parameter to the query patter
`.&? param` - the same but parameter is treated as optional
`|` - matches either left or right parameter

